### PR TITLE
fix without buildkit

### DIFF
--- a/sample-application/consumer/Dockerfile
+++ b/sample-application/consumer/Dockerfile
@@ -1,13 +1,8 @@
-# syntax=docker/dockerfile:experimental
-
 FROM maven:latest as mavenBuild
 WORKDIR /app
 COPY pom.xml .
 # 
-RUN --mount=type=cache,target=/root/.m2 \
-  mvn dependency:resolve-plugins && \
-  mvn dependency:resolve && \
-  mvn dependency:go-offline
+RUN mvn -B package -Dmaven.test.skip -Dmaven.main.skip && rm -r target
 # Copy all other project files and build project
 COPY src ./src
 RUN mvn -B package -Dmaven.test.skip


### PR DESCRIPTION
Hello,

Here is davidxxx from SO. The download problem is not a new download problem but a downloading of plugins with different versions according to the maven goal specified ! Woua !

I found an acceptable workaround without buildkit.  i added a pull request to show you.
But as said that would be never as efficient as the buildkit way :)